### PR TITLE
fix for underfined references

### DIFF
--- a/wrapper.go
+++ b/wrapper.go
@@ -4,6 +4,7 @@ package triangle
 #include "triangle.h"
 #include <stdlib.h>
 */
+// #cgo LDFLAGS: -lm
 import "C"
 import "unsafe"
 


### PR DESCRIPTION
when i'm trying to build github.com/fogleman/choppy  I'm getting: 

/tmp/go-build642325243/github.com/fogleman/triangle/_obj/triangle.o: In function `parsecommandline':
../triangle/triangle.c:3523: undefined reference to `cos'
...
etc. 
