### PR TITLE
Avoid writing Go pointers to non Go memory

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/pradeep-pyro/triangle
+
+go 1.17

--- a/triangle.go
+++ b/triangle.go
@@ -3,6 +3,7 @@ package triangle
 import (
 	"fmt"
 	"strconv"
+	"unsafe"
 )
 
 type SegmentSplitting uint8
@@ -116,6 +117,8 @@ func ConstrainedDelaunay(pts [][2]float64, segs [][2]int32,
 	in := NewTriangulateIO()
 	out := NewTriangulateIO()
 	defer FreeTriangulateIO(in)
+	// this is duplicated in out, so free it only once
+	defer trifree(unsafe.Pointer(in.ct.holelist))
 	defer FreeTriangulateIO(out)
 
 	in.SetPoints(pts)
@@ -139,6 +142,8 @@ func ConformingDelaunay(pts [][2]float64, segs [][2]int32,
 	in := NewTriangulateIO()
 	out := NewTriangulateIO()
 	defer FreeTriangulateIO(in)
+	// this is duplicated in out, so free it only once
+	defer trifree(unsafe.Pointer(in.ct.holelist))
 	defer FreeTriangulateIO(out)
 
 	in.SetPoints(pts)

--- a/triangle_test.go
+++ b/triangle_test.go
@@ -1,0 +1,93 @@
+package triangle
+
+import "testing"
+
+// To test if this library adheres to the passing pointers rules as mentioned in
+// https://pkg.go.dev/cmd/cgo#hdr-Passing_pointers, run the test suite with the
+// command
+//
+//     GODEBUG=cgocheck=2 go test -gcflags=all=-d=checkptr
+
+// Points forming a spiral shape (https://www.cs.cmu.edu/~quake/spiral.node)
+var delaunayVoronoiTestPts = [][2]float64{
+	{0, 0}, {-0.416, 0.909}, {-1.35, 0.436}, {-1.64, 0.549},
+	{-1.31, -1.51}, {-0.532, -2.17}, {0.454, -2.41}, {1.45, -2.21},
+	{2.29, -1.66}, {2.88, -0.838}, {3.16, 0.131}, {3.12, 1.14},
+	{2.77, 2.08}, {2.16, 2.89}, {1.36, 3.49},
+}
+
+func TestDelaunay(t *testing.T) {
+	triangles := Delaunay(delaunayVoronoiTestPts)
+	const numExpectedTriangles = 16
+	assertEq(t, numExpectedTriangles, len(triangles),
+		"Did not get expected number of triangles")
+}
+
+func TestVoronoi(t *testing.T) {
+	vertices, edges, rayOrigins, rayDirections := Voronoi(delaunayVoronoiTestPts)
+
+	const (
+		numExpectedVertices      = 16
+		numExpectedEdges         = numExpectedVertices + 2
+		numExpectedRayOrigins    = 12
+		numExpectedRayDirections = numExpectedRayOrigins
+	)
+
+	assertEq(t, numExpectedVertices, len(vertices),
+		"Did not get expected number of vertices")
+	assertEq(t, numExpectedEdges, len(edges),
+		"Did not get expected number of edges")
+	assertEq(t, numExpectedRayOrigins, len(rayOrigins),
+		"Did not get expected number of ray origins")
+	assertEq(t, numExpectedRayDirections, len(rayDirections),
+		"Did not get expected number of ray directions")
+}
+
+func TestConstrainedConformingDelaunay(t *testing.T) {
+	// Points forming the shape of letter "A"
+	var pts = [][2]float64{{0.200000, -0.776400}, {0.220000, -0.773200},
+		{0.245600, -0.756400}, {0.277600, -0.702000}, {0.488800, -0.207600}, {0.504800, -0.207600}, {0.740800, -0.7396}, {0.756000, -0.761200},
+		{0.774400, -0.7724}, {0.800000, -0.776400}, {0.800000, -0.792400}, {0.579200, -0.792400}, {0.579200, -0.776400}, {0.621600, -0.771600},
+		{0.633600, -0.762800}, {0.639200, -0.744400}, {0.620800, -0.684400}, {0.587200, -0.604400}, {0.360800, -0.604400}, {0.319200, -0.706800},
+		{0.312000, -0.739600}, {0.318400, -0.761200}, {0.334400, -0.771600}, {0.371200, -0.776400}, {0.371200, -0.792400}, {0.374400, -0.570000},
+		{0.574400, -0.5700}, {0.473600, -0.330800}, {0.200000, -0.792400},
+	}
+	// Segments connecting the points
+	var segs = [][2]int32{{28, 0}, {0, 1}, {1, 2}, {2, 3}, {3, 4}, {4, 5}, {5, 6}, {6, 7}, {7, 8}, {8, 9}, {9, 10}, {10, 11}, {11, 12}, {12, 13}, {13, 14}, {14, 15}, {15, 16}, {16, 17}, {17, 18}, {18, 19}, {19, 20}, {20, 21}, {21, 22}, {22, 23}, {23, 24}, {24, 28}, {25, 26}, {26, 27}, {27, 25}}
+	// Hole represented by a point lying inside it
+	var holes = [][2]float64{
+		{0.47, -0.5},
+	}
+	verts, faces := ConstrainedDelaunay(pts, segs, holes)
+
+	const (
+		numExpectedConstrainedVertices = 29
+		numExpectedConstrainedFaces    = numExpectedConstrainedVertices
+	)
+
+	assertEq(t, numExpectedConstrainedVertices, len(verts),
+		"ConstrainedDelaunay: Did not get expected number of vertices")
+	assertEq(t, numExpectedConstrainedFaces, len(faces),
+		"ConstrainedDelaunay: Did not get expected number of faces")
+
+	const (
+		numExpectedConformingVertices = 61
+		numExpectedConformingFaces    = numExpectedConformingVertices
+	)
+
+	verts, faces = ConformingDelaunay(pts, segs, holes)
+
+	assertEq(t, numExpectedConformingVertices, len(verts),
+		"ConformingDelaunay: Did not get expected number of vertices")
+	assertEq(t, numExpectedConformingFaces, len(faces),
+		"ConformingDelaunay: Did not get expected number of faces")
+
+}
+
+func assertEq(t *testing.T, expected, actual int, msg string) {
+	t.Helper()
+	if expected != actual {
+		t.Log(msg)
+		t.Fatalf("Expected %d, but was %d", expected, actual)
+	}
+}

--- a/wrapper.go
+++ b/wrapper.go
@@ -69,23 +69,23 @@ func (t *triangulateIO) NumberOfTriangles() int {
 }
 
 func (t *triangulateIO) Normals() [][2]float64 {
-	return cArrToFlt64Slice2D(unsafe.Pointer(t.ct.normlist), t.NumberOfEdges())
+	return cArrToFlt64Slice2D(t.ct.normlist, t.NumberOfEdges())
 }
 
 func (t *triangulateIO) Edges() [][2]int32 {
-	return cArrToIntSlice2D(unsafe.Pointer(t.ct.edgelist), t.NumberOfEdges())
+	return cArrToIntSlice2D(t.ct.edgelist, t.NumberOfEdges())
 }
 
 func (t *triangulateIO) Points() [][2]float64 {
-	return cArrToFlt64Slice2D(unsafe.Pointer(t.ct.pointlist), t.NumberOfPoints())
+	return cArrToFlt64Slice2D(t.ct.pointlist, t.NumberOfPoints())
 }
 
 func (t *triangulateIO) PointMarkers() []int32 {
-	return cArrToIntSlice(unsafe.Pointer(t.ct.pointmarkerlist), t.NumberOfPoints())
+	return cArrToIntSlice(t.ct.pointmarkerlist, t.NumberOfPoints())
 }
 
 func (t *triangulateIO) Segments() [][2]int32 {
-	return cArrToIntSlice2D(unsafe.Pointer(t.ct.segmentlist), t.NumberOfSegments())
+	return cArrToIntSlice2D(t.ct.segmentlist, t.NumberOfSegments())
 }
 
 func (t *triangulateIO) SetEdges(edges [][2]int32) {
@@ -125,7 +125,7 @@ func (t *triangulateIO) SetHoles(holes [][2]float64) {
 }
 
 func (t *triangulateIO) Triangles() [][3]int32 {
-	return cArrToIntSlice3D(unsafe.Pointer(t.ct.trianglelist), t.NumberOfTriangles())
+	return cArrToIntSlice3D(t.ct.trianglelist, t.NumberOfTriangles())
 }
 
 func triang(opt string, in, out, vorout *triangulateIO) {
@@ -138,8 +138,8 @@ func triang(opt string, in, out, vorout *triangulateIO) {
 	}
 }
 
-func cArrToIntSlice(ptr unsafe.Pointer, length int) []int32 {
-	slice := (*[1 << 30]C.int)(ptr)[:length:length]
+func cArrToIntSlice(ptr *C.int, length int) []int32 {
+	slice := (*[1 << 30]C.int)(unsafe.Pointer(ptr))[:length:length]
 	result := make([]int32, length)
 	for i := 0; i < length; i++ {
 		result[i] = int32(slice[i])
@@ -147,9 +147,9 @@ func cArrToIntSlice(ptr unsafe.Pointer, length int) []int32 {
 	return result
 }
 
-func cArrToIntSlice2D(ptr unsafe.Pointer, length int) [][2]int32 {
+func cArrToIntSlice2D(ptr *C.int, length int) [][2]int32 {
 	sz := length * 2
-	slice := (*[1 << 30]C.int)(ptr)[:sz:sz]
+	slice := (*[1 << 30]C.int)(unsafe.Pointer(ptr))[:sz:sz]
 	result := make([][2]int32, length)
 	for i := 0; i < length; i++ {
 		j := i * 2
@@ -158,9 +158,9 @@ func cArrToIntSlice2D(ptr unsafe.Pointer, length int) [][2]int32 {
 	return result
 }
 
-func cArrToIntSlice3D(ptr unsafe.Pointer, length int) [][3]int32 {
+func cArrToIntSlice3D(ptr *C.int, length int) [][3]int32 {
 	sz := length * 3
-	slice := (*[1 << 30]C.int)(ptr)[:sz:sz]
+	slice := (*[1 << 30]C.int)(unsafe.Pointer(ptr))[:sz:sz]
 	result := make([][3]int32, length)
 	for i := 0; i < length; i++ {
 		j := i * 3
@@ -169,18 +169,9 @@ func cArrToIntSlice3D(ptr unsafe.Pointer, length int) [][3]int32 {
 	return result
 }
 
-func cArrToFlt64Slice(ptr unsafe.Pointer, length int) []float64 {
-	slice := (*[1 << 30]C.double)(ptr)[:length:length]
-	result := make([]float64, length)
-	for i := 0; i < length; i++ {
-		result[i] = float64(slice[i])
-	}
-	return result
-}
-
-func cArrToFlt64Slice2D(ptr unsafe.Pointer, length int) [][2]float64 {
+func cArrToFlt64Slice2D(ptr *C.double, length int) [][2]float64 {
 	sz := length * 2
-	slice := (*[1 << 30]C.double)(ptr)[:sz:sz]
+	slice := (*[1 << 30]C.double)(unsafe.Pointer(ptr))[:sz:sz]
 	result := make([][2]float64, length)
 	for i := 0; i < length; i++ {
 		j := i * 2


### PR DESCRIPTION
Hi, thank you for this wrapper! I've been using it on and off for a while, and for me it seems to work as intended for the most part. However, in some situations, I ended up with segmentation faults without any good explanation why.

Yesterday I decided to take a look by using cgo and gc debug flags, and found out that this wrapper passes in Go pointers to C. [Passing Go pointers to C](https://pkg.go.dev/cmd/cgo#hdr-Passing_pointers) isn't allowed because Go's garbage collector may kick in at any time. I couldn't see any other backwards compatible way to do this except copying the slice contents into C memory.

I also did a best effort attempt to clean up C memory after use, although I am not aware of how all the options work. At least one of the pointers – `holelist` - were copied to the out struct, and that caused issues with double freeing. I wouldn't be surprised if this could be a problem with other allocated memory blocks. There's no double free with the default helper functions, but I guess other flags/options could trigger return values that would be double free'd. This would be a lot simpler if the functions calling triangle either gathered all input/output in a single struct, or did not expose cleanup. However, that would break backwards compatibility.

Finally, Go complained so much about no Go module file that I added an empty one – hopefully that's fine.